### PR TITLE
chore: add Cursor Approval Agent policy files

### DIFF
--- a/.cursor/approval-policies/ROUTING.md
+++ b/.cursor/approval-policies/ROUTING.md
@@ -1,0 +1,19 @@
+- product: Documentation
+  boundary: "{docs/**,**/README.md,**/CHANGELOG.md,**/*.md}"
+  policies:
+    - .cursor/approval-policies/docs-policy.md
+
+- product: CI and workflows
+  boundary: ".github/workflows/**"
+  policies:
+    - .cursor/approval-policies/ci-policy.md
+
+- product: Tests
+  boundary: "{**/test/**,**/tests/**,**/*.test.*,**/*.spec.*,e2e/**}"
+  policies:
+    - .cursor/approval-policies/tests-policy.md
+
+- product: Application runtime
+  boundary: "{src/**,app/**,lib/**,packages/**,convex/**,agents/**,lambdas/**}"
+  policies:
+    - .cursor/approval-policies/runtime-policy.md

--- a/.cursor/approval-policies/ci-policy.md
+++ b/.cursor/approval-policies/ci-policy.md
@@ -1,0 +1,9 @@
+# CI workflow approval policy
+
+## Default posture
+Never auto-approve workflow changes.
+
+## Human review must verify
+- Required checks are not removed without replacement
+- Permissions blocks are not unnecessarily broadened
+- Deploy/release gates remain intact

--- a/.cursor/approval-policies/docs-policy.md
+++ b/.cursor/approval-policies/docs-policy.md
@@ -1,0 +1,9 @@
+# Documentation approval policy
+
+## Auto-approve when
+- Markdown/copy-only changes with no executable code
+- Bugbot and Security Agent report no findings
+
+## Never auto-approve
+- Embedded secrets, tokens, or private infrastructure endpoints
+- Bundled runtime changes in the same PR

--- a/.cursor/approval-policies/runtime-policy.md
+++ b/.cursor/approval-policies/runtime-policy.md
@@ -1,0 +1,8 @@
+# Application runtime approval policy
+
+## Auto-approve when
+- Small localized fix with tests and clean automated review
+- No auth, billing, health-data, or deploy config impact
+
+## Never auto-approve
+- Broad refactors, new external integrations, or removed guardrails

--- a/.cursor/approval-policies/tests-policy.md
+++ b/.cursor/approval-policies/tests-policy.md
@@ -1,0 +1,8 @@
+# Tests approval policy
+
+## Auto-approve when
+- Test-only changes with unchanged production logic
+- CI green; Bugbot/Security clean
+
+## Never auto-approve
+- Disabled/skipped tests paired with production logic changes

--- a/APPROVAL_POLICY.md
+++ b/APPROVAL_POLICY.md
@@ -1,0 +1,37 @@
+# .github — default approval policy
+
+Repository-wide rules for Cursor Approval Agents evaluating pull requests in this repo.
+
+## Purpose
+
+.github default approval policy for Cursor Approval Agents.
+
+Default posture: **approve only when risk is low and automated review is clean**.
+
+## Auto-approve when ALL are true
+
+- Bugbot Review Context reports no findings requiring human review
+- Security Review Context reports no findings requiring human review (when enabled)
+- Risk score is at or below the agent's configured maximum threshold
+- CI checks required for the changed paths are green
+- PR does not modify approval policy files or routing files
+- Documentation-only or test-only PRs (≤ 300 lines excluding lockfiles)
+
+## Never auto-approve
+
+- GitHub Actions workflow changes that weaken CI, skip tests, or broaden deploy permissions
+- Deletions or relaxations of auth, security, or safety guardrails
+- Changes that remove tests, disable lint/typecheck, or bypass pre-commit hooks
+- PRs labeled `security`, `breaking`, or `do-not-auto-approve`
+
+## Reviewer routing
+
+When auto-approval is not allowed, request repo maintainers or the appropriate team for the changed area. Leave the PR unapproved with a short comment if reviewer assignment is unavailable.
+
+## Deploy expectations
+
+For changes shipping dev → staging → main → production: do not auto-approve solely on green CI if production paths, migrations, or release config changed.
+
+## Conflict resolution
+
+Follow the most specific applicable policy. If unclear, follow the stricter rule and do not auto-approve.


### PR DESCRIPTION
## Summary
- Add APPROVAL_POLICY.md and .cursor/approval-policies/ routing (force-added)

## Test plan
- [x] ROUTING.md present on branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only policy configuration with no runtime, CI, or application code changes.
> 
> **Overview**
> Introduces **Cursor Approval Agent** governance for this repo: a root **`APPROVAL_POLICY.md`** defines the default posture (auto-approve only when risk is low and automated review is clean), global never-auto-approve cases, reviewer routing, deploy expectations, and conflict resolution (stricter / more specific policy wins).
> 
> Adds **`.cursor/approval-policies/ROUTING.md`** to map changed paths to area-specific policies—documentation, CI/workflows, tests, and application runtime (`src`, `app`, `convex`, `agents`, `lambdas`, etc.). Each area gets a small policy file: docs and tests allow narrow auto-approve paths; **CI workflows never auto-approve**; runtime allows only small, low-risk fixes with tests and blocks broad refactors and guardrail removals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f591ecdc6179b8f0bab38a5089fcbb141bffb506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->