### PR TITLE
ci(security): reusable gitleaks secret-scan workflow

### DIFF
--- a/.github/workflows/secret-scan-reusable.yml
+++ b/.github/workflows/secret-scan-reusable.yml
@@ -1,0 +1,52 @@
+name: Reusable secret scan (gitleaks CLI)
+
+# Org-level reusable workflow. Call from any private repo as compensating
+# control while GitHub Secret Protection is enterprise-policy blocked.
+# Uses gitleaks CLI (MIT), NOT gitleaks-action (commercial EULA + license key).
+# gitleaks is feature-complete (security patches only) — succession: Betterleaks.
+# TruffleHog verified mode is NOT enabled (AGPL + live credential probes need
+# PHI egress review).
+
+on:
+  workflow_call:
+    inputs:
+      gitleaks_version:
+        description: gitleaks release tag without v
+        type: string
+        default: "8.30.1"
+        required: false
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks CLI
+        env:
+          VERSION: ${{ inputs.gitleaks_version }}
+        run: |
+          set -euo pipefail
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | tar -xz gitleaks
+          sudo -S -p '' mv gitleaks /usr/local/bin/
+          gitleaks version
+
+      - name: Scan PR / push range
+        env:
+          BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [ -n "${BASE:-}" ] && [ "$BASE" != "0000000000000000000000000000000000000000" ] \
+             && git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
+            gitleaks git --log-opts="${BASE}..${HEAD}" --no-banner --verbose --redact
+          else
+            gitleaks git --no-banner --verbose --redact
+          fi

--- a/profile/secret-scan-caller.example.yml
+++ b/profile/secret-scan-caller.example.yml
@@ -1,0 +1,10 @@
+# Drop into a repo as .github/workflows/secret-scan.yml
+name: Secret Scan
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+jobs:
+  scan:
+    uses: Lifecycle-Innovations-Limited/.github/.github/workflows/secret-scan-reusable.yml@main


### PR DESCRIPTION
## Why
GHAS Secret Protection remains failed on 27 active private LIL repos. Need free reusable CI secret scan.

## How
Reusable gitleaks CLI workflow + example caller under profile/.

## How tested
YAML only. healify-web#1952 ships an inline equivalent first.

## Not validated
First org reusable workflow call permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated secret scanning for code changes and repository history.
  * Added configurable scanning tool version support.
  * Added an example workflow for scanning pushes and pull requests targeting key branches.
  * Scans use read-only repository access and skip automated dependency-update runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->